### PR TITLE
Fixed timestamping

### DIFF
--- a/px_hardware_interface/px4flow_node/src/SerialComm.cc
+++ b/px_hardware_interface/px4flow_node/src/SerialComm.cc
@@ -164,7 +164,7 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
 
                 px_comm::OpticalFlow optFlowMsg;
 
-                optFlowMsg.header.stamp = ros::Time(flow.time_usec / 1000000, flow.time_usec % 1000000);
+                optFlowMsg.header.stamp = ros::Time(flow.time_usec / 1000000, (flow.time_usec % 1000000) * 1000);
                 optFlowMsg.header.frame_id = m_frameId;
                 optFlowMsg.ground_distance = flow.ground_distance;
                 optFlowMsg.flow_x = flow.flow_x;


### PR DESCRIPTION
The second argument of the `ros::Time` ctor expects nanoseconds, but it was feeding by microseconds.
