### PR TITLE
PX4Flow message stamps according to ROS clock

### DIFF
--- a/drivers/px4flow/include/px4flow/SerialComm.h
+++ b/drivers/px4flow/include/px4flow/SerialComm.h
@@ -53,6 +53,14 @@ private:
     int m_errorCount;
 
     bool m_connected;
+
+    ros::Time ros_time_init;
+    ros::Time stamp;
+    ros::Duration time_diff;
+    int sensor_ini_usec;
+    bool first_step;
+    bool second_step;
+    bool third_step;
 };
 
 }

--- a/drivers/px4flow/include/px4flow/SerialComm.h
+++ b/drivers/px4flow/include/px4flow/SerialComm.h
@@ -54,6 +54,8 @@ private:
 
     bool m_connected;
 
+    mavlink_optical_flow_t flow;
+    
     ros::Time ros_time_init;
     ros::Time stamp;
     ros::Duration time_diff;

--- a/drivers/px4flow/include/px4flow/SerialComm.h
+++ b/drivers/px4flow/include/px4flow/SerialComm.h
@@ -60,9 +60,8 @@ private:
     ros::Time stamp;
     ros::Duration time_diff;
     int sensor_ini_usec;
-    bool first_step;
-    bool second_step;
-    bool third_step;
+    bool time_ok;
+    int nstep;
 };
 
 }

--- a/drivers/px4flow/include/px4flow/SerialComm.h
+++ b/drivers/px4flow/include/px4flow/SerialComm.h
@@ -17,7 +17,7 @@ public:
     SerialComm(const std::string& frameId);
     ~SerialComm();
 
-    bool open(const std::string& portStr, int baudrate);
+    bool open(const std::string& portStr, int baudrate, bool output_filtered, int filter_window_size);
     void close(void);
 
 private:
@@ -62,6 +62,11 @@ private:
     int sensor_ini_usec;
     bool time_ok;
     int nstep;
+
+    std::vector<std::vector<double> > reading_queue_;
+    bool output_filtered_;
+    int filter_window_size_;
+
 };
 
 }

--- a/drivers/px4flow/launch/px4flow_parameters.yaml
+++ b/drivers/px4flow/launch/px4flow_parameters.yaml
@@ -1,2 +1,4 @@
 serial_port: /dev/ttyACM0
 baudrate:    115200
+output_filtered: true
+filter_window_size: 5

--- a/drivers/px4flow/launch/px4flow_parameters.yaml
+++ b/drivers/px4flow/launch/px4flow_parameters.yaml
@@ -1,2 +1,2 @@
-serial_port: /dev/ttyS0
+serial_port: /dev/ttyACM0
 baudrate:    115200

--- a/drivers/px4flow/src/SerialComm.cc
+++ b/drivers/px4flow/src/SerialComm.cc
@@ -209,6 +209,8 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
                     // Add newest reading
                     reading_queue_.push_back(pub_data);
   
+                    std::cout << "QUEUE: [";
+
                     // Compute mean
                     std::vector<double> readsum(5);
                     for (int ii = 0; ii < reading_queue_.size(); ++ii)
@@ -218,6 +220,9 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
                       readsum.at(2) = readsum.at(2) + reading_queue_.at(ii).at(2);
                       readsum.at(3) = readsum.at(3) + reading_queue_.at(ii).at(3);
                       readsum.at(4) = readsum.at(4) + reading_queue_.at(ii).at(4);
+
+                      std::cout << reading_queue_.at(ii).at(3) << ",";
+
                     }
 
                     pub_data.clear();
@@ -225,6 +230,10 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
                     {
                       pub_data.push_back(readsum.at(ii)/reading_queue_.size());
                     }
+
+                    std::cout << "]  MEAN: " << pub_data.at(3) << std::endl;
+
+
 
                     // Clean oldest reading
                     if (reading_queue_.size() > filter_window_size_-1)

--- a/drivers/px4flow/src/SerialComm.cc
+++ b/drivers/px4flow/src/SerialComm.cc
@@ -237,7 +237,7 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
 
                     // Clean oldest reading
                     if (reading_queue_.size() > filter_window_size_-1)
-                      reading_queue_.pop_back();
+                      reading_queue_.erase(reading_queue_.begin());
                   }
 
                   // Publish message

--- a/drivers/px4flow/src/SerialComm.cc
+++ b/drivers/px4flow/src/SerialComm.cc
@@ -209,8 +209,6 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
                     // Add newest reading
                     reading_queue_.push_back(pub_data);
   
-                    std::cout << "QUEUE: [";
-
                     // Compute mean
                     std::vector<double> readsum(5);
                     for (int ii = 0; ii < reading_queue_.size(); ++ii)
@@ -220,9 +218,6 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
                       readsum.at(2) = readsum.at(2) + reading_queue_.at(ii).at(2);
                       readsum.at(3) = readsum.at(3) + reading_queue_.at(ii).at(3);
                       readsum.at(4) = readsum.at(4) + reading_queue_.at(ii).at(4);
-
-                      std::cout << reading_queue_.at(ii).at(3) << ",";
-
                     }
 
                     pub_data.clear();
@@ -230,10 +225,6 @@ SerialComm::readCallback(const boost::system::error_code& error, size_t bytesTra
                     {
                       pub_data.push_back(readsum.at(ii)/reading_queue_.size());
                     }
-
-                    std::cout << "]  MEAN: " << pub_data.at(3) << std::endl;
-
-
 
                     // Clean oldest reading
                     if (reading_queue_.size() > filter_window_size_-1)

--- a/drivers/px4flow/src/px4flow_node.cc
+++ b/drivers/px4flow/src/px4flow_node.cc
@@ -44,8 +44,14 @@ main(int argc, char** argv)
     std::string frameId;
     pnh.param("frame_id", frameId, std::string("/px4flow"));
 
+    bool output_filtered;
+    pnh.param("output_filtered", output_filtered, false);
+
+    int filter_window_size;
+    pnh.param("filter_window_size", filter_window_size, 5);
+
     px::SerialComm comm(frameId);
-    if (!comm.open(portStr, baudrate))
+    if (!comm.open(portStr, baudrate, output_filtered, filter_window_size))
     {
         return -1;
     }

--- a/px_comm/package.xml
+++ b/px_comm/package.xml
@@ -11,6 +11,13 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
 
   <run_depend>message_runtime</run_depend>
+  <run_depend>geometry_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+
+
+
 </package>


### PR DESCRIPTION
Hi, 

With your current PX4flow driver version the ROS messages come with the sensor clock as stamp (more stable and regular than ROS clock). 
This means that they cannot be used directly in other nodes that require a stamp check. 
Basically the sensor clock starts when the hardware is powered, thus provoking a big time stamp jump between actual ROS clock and the stamp appended to the messages.

A usual solution here could be to add a ROS::Time::now() in the message stamps before publishing them (considering the high frame rate), however in this particular case the publisher objects are inside a for loop that depends on the serial reading. 
Through the serial can come several packages of the same type, flow for instance, thus all published message would have the same time stamp using ROS::Time::now().

Instead, the patch gets the sensor clock when is stable (after first serial reading) and synchronizes the message stamps considering the ROS clock when this is stable (after a second or so).

By the way, I added also the time stamp to the image messages in case they are published.

I believe this is useful for a general purpose. 

If you feel the pull request cannot be accepted, I will keep the fork.

Thank you for your time. 

All the best, 

Angel.
